### PR TITLE
Replaces sanitized name with base64 encoding/decoding and adds title for batch runs

### DIFF
--- a/autoreduce_db/instrument/models.py
+++ b/autoreduce_db/instrument/models.py
@@ -26,7 +26,7 @@ class Variable(models.Model):
         """
         Encodes the name in a urlsafe base64 representaiton.
         Used to encode variable names with any character without
-special handling for having whitespaces or special characters.
+        special handling for having whitespaces or special characters.
         """
         # pylint:disable=no-member
         return base64.urlsafe_b64encode(self.name.encode("utf-8")).decode("utf-8")

--- a/autoreduce_db/instrument/models.py
+++ b/autoreduce_db/instrument/models.py
@@ -7,6 +7,7 @@
 """
 Definition of Variable classes used for the WebApp model
 """
+import base64
 from django.db import models
 from autoreduce_db.reduction_viewer.models import Instrument, ReductionRun
 
@@ -21,12 +22,21 @@ class Variable(models.Model):
     is_advanced = models.BooleanField(default=False)
     help_text = models.TextField(blank=True, null=True, default='')
 
-    def sanitized_name(self):
+    def encode_name_b64(self):
         """
-        Returns a HTMl-friendly name that can be used as element IDs or form input names
+        Encodes the name in a urlsafe base64 representaiton.
+        Used to encode variable names with any character without
+special handling for having whitespaces or special characters.
         """
         # pylint:disable=no-member
-        return self.name.replace(' ', '-')
+        return base64.urlsafe_b64encode(self.name.encode("utf-8")).decode("utf-8")
+
+    @staticmethod
+    def decode_name_b64(b64_encoded_name: str):
+        """
+        Decodes the base64 representation back to utf-8 string.
+        """
+        return base64.urlsafe_b64decode(b64_encoded_name).decode("utf-8")
 
 
 class InstrumentVariable(Variable):
@@ -46,7 +56,7 @@ class InstrumentVariable(Variable):
 
     # pylint:disable=no-member
     def __str__(self):
-        return f"{self.instrument.name} - {self.name}=self.value"
+        return f"{self.instrument.name} - {self.name}={self.value}"
 
 
 class RunVariable(models.Model):

--- a/autoreduce_db/reduction_viewer/models.py
+++ b/autoreduce_db/reduction_viewer/models.py
@@ -178,10 +178,7 @@ class ReductionRun(models.Model):
         Return str representation of reduction run based on run name if available else run number
         :return: str representation of ReductionRun
         """
-        if self.run_description:
-            return f"{self.run_number} - v{self.run_version} : {self.run_description}"
-        else:
-            return f"{self.run_number} - v{self.run_version}"
+        return self.title()
 
     def title(self):
         """

--- a/autoreduce_db/reduction_viewer/models.py
+++ b/autoreduce_db/reduction_viewer/models.py
@@ -188,11 +188,11 @@ class ReductionRun(models.Model):
         try:
             title = '%s' % self.run_number
         except ValueError:
-            title = '%s' % [run.run_number for run in self.run_numbers.all()]
-        if self.run_description:
-            title += ' - %s' % self.run_description
+            title = 'Batch %s → %s' % (self.run_numbers.first(), self.run_numbers.last())
         if self.run_version > 0:
             title += ' - %s' % self.run_version
+        if self.run_description:
+            title += ' - %s' % self.run_description
         return title
 
     @property

--- a/autoreduce_db/reduction_viewer/test/test_reduction_run.py
+++ b/autoreduce_db/reduction_viewer/test/test_reduction_run.py
@@ -23,7 +23,7 @@ class TestReductionRun(TestCase):
     def test_title_multiple_run_numbers(self):
         """Test that retrieving the status returns the expected one"""
         self.reduction_run.run_numbers.create(run_number=123457)
-        assert self.reduction_run.title() == "[123456, 123457] - This is the test run_description"
+        assert self.reduction_run.title() == "Batch 123456 → 123457 - This is the test run_description"
 
     def test_run_number(self):
         """Test that retrieving the status returns the expected one"""

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='autoreduce_db',
-      version='22.0.0.dev11',
+      version='22.0.0.dev12',
       description='ISIS Autoreduce',
       author='ISIS Autoreduction Team',
       url='https://github.com/ISISScientificComputing/autoreduce-db/',


### PR DESCRIPTION
Used to encode variable names with any character without
special handling for having whitespaces or special characters.### Summary of work
<!---The changes you have made--->

### How to test your work
<!---This can be a link to the---> 

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #xyz


**Before merging ensure the release notes have been updated**