### PR TITLE
Use run description for batch runs and run title for non-batch runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,6 +40,15 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+      - name: Build package for publishing
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: python3 -m pip install wheel && python3 setup.py sdist bdist_wheel
+
+      - name: Publish distribution 📦 to PyPI
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   dependency-check:
     name: Dependency-Check

--- a/autoreduce_db/autoreduce_django/fixtures/run_with_multiple_variables.json
+++ b/autoreduce_db/autoreduce_django/fixtures/run_with_multiple_variables.json
@@ -22,7 +22,7 @@
         "fields": {
             "status_id": 5,
             "run_version": 0,
-            "run_description": "This is the test run_description",
+            "run_description": "",
             "last_updated": "2020-10-19 17:35:04+00:00",
             "created": "2020-10-19 17:30:04+00:00",
             "reduction_log": "test_log",

--- a/autoreduce_db/autoreduce_django/fixtures/run_with_multiple_variables.json
+++ b/autoreduce_db/autoreduce_django/fixtures/run_with_multiple_variables.json
@@ -20,7 +20,7 @@
         "model": "reduction_viewer.reductionrun",
         "pk": 1,
         "fields": {
-            "status_id": 2,
+            "status_id": 5,
             "run_version": 0,
             "run_description": "This is the test run_description",
             "last_updated": "2020-10-19 17:35:04+00:00",
@@ -72,7 +72,7 @@
         "model": "reduction_viewer.instrument",
         "pk": 1,
         "fields": {
-            "name": "TestInstrument",
+            "name": "TESTINSTRUMENT",
             "is_active": true,
             "is_paused": false
         }

--- a/autoreduce_db/reduction_viewer/models.py
+++ b/autoreduce_db/reduction_viewer/models.py
@@ -278,8 +278,10 @@ class ReductionRun(models.Model):
         if self.run_version > 0:
             title += f" - {self.run_version}"
 
-        if self.run_title:
+        if not self.batch_run and self.run_title:
             title += f" - {self.run_title}"
+        elif self.batch_run and self.run_description:
+            title += f" - {self.run_description}"
 
         return title
 

--- a/autoreduce_db/reduction_viewer/test/test_reduction_run.py
+++ b/autoreduce_db/reduction_viewer/test/test_reduction_run.py
@@ -63,6 +63,7 @@ class TestReductionRun(TestCase):
         """
         next_run = 123457
         self.reduction_run.run_numbers.create(run_number=next_run)
+        self.reduction_run.batch_run = True
         assert self.reduction_run.title() == f"Batch 123456 → {next_run}"
 
     def test_title_with_multiple_run_numbers_and_version(self):
@@ -73,6 +74,7 @@ class TestReductionRun(TestCase):
         """
         next_run = 123457
         self.reduction_run.run_numbers.create(run_number=next_run)
+        self.reduction_run.batch_run = True
         run_version = self.reduction_run.run_version = 2
         assert self.reduction_run.title() == f"Batch 123456 → {next_run} - {run_version}"
 
@@ -84,8 +86,11 @@ class TestReductionRun(TestCase):
         """
         next_run = 123457
         self.reduction_run.run_numbers.create(run_number=next_run)
-        run_title = self.reduction_run.run_title = "larmor0102"
-        assert self.reduction_run.title() == f"Batch 123456 → {next_run} - {run_title}"
+        self.reduction_run.batch_run = True
+        self.reduction_run.run_title = "larmor0102"
+        run_description = self.reduction_run.run_description = "test description"
+        result_title = self.reduction_run.title()
+        assert result_title == f"Batch 123456 → {next_run} - {run_description}"
 
     def test_title_with_multiple_run_numbers_and_title_and_version(self):
         """
@@ -95,9 +100,12 @@ class TestReductionRun(TestCase):
         """
         next_run = 123457
         self.reduction_run.run_numbers.create(run_number=next_run)
+        self.reduction_run.batch_run = True
         run_version = self.reduction_run.run_version = 2
-        run_title = self.reduction_run.run_title = "larmor0102"
-        assert self.reduction_run.title() == f"Batch 123456 → {next_run} - {run_version} - {run_title}"
+        self.reduction_run.run_title = "larmor0102"
+        run_description = self.reduction_run.run_description = "test description"
+        assert self.reduction_run.title() == f"Batch 123456 → {next_run} - {run_version} - {run_description}"
+        assert str(self.reduction_run) == f"Batch 123456 → {next_run} - {run_version} - {run_description}"
 
     def test_run_number(self):
         """Test that retrieving the status returns the expected one."""

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='autoreduce_db',
-    version='22.0.0.dev18',
+    version='22.0.0.dev19',
     description='ISIS Autoreduce',
     author='ISIS Autoreduction Team',
     url='https://github.com/ISISScientificComputing/autoreduce-db/',


### PR DESCRIPTION
### Summary of work
Changes what fields `.title()` uses - batch runs now use the `self.run_description`, while non-batch ones will use `self.run_title`

### How to test your work
Check that the batch runs don't have `[",",",","]` anymore!
